### PR TITLE
added method spread_orientations to task modify_VE

### DIFF
--- a/matflow_damask/main.py
+++ b/matflow_damask/main.py
@@ -26,6 +26,7 @@ from damask_parse.utils import (
     add_volume_element_buffer_zones,
     validate_orientations,
     validate_volume_element,
+    spread_orientations,
 )
 from damask_parse import __version__ as damask_parse_version
 from matflow.scripting import get_wrapper_script
@@ -339,6 +340,12 @@ def modify_volume_element_add_buffer_zones(volume_element, buffer_sizes,
         )
     }
     return out
+
+
+@func_mapper(task='modify_volume_element', method='spread_orientations')
+def modify_volume_element_spread_orientations(volume_element, phases, stddev_degrees):
+    VE = spread_orientations(volume_element, phases, sigmas=stddev_degrees)
+    return {"volume_element": VE}
 
 
 @func_mapper(task='modify_volume_element', method='new_orientations')


### PR DESCRIPTION
# task: modify_volume_element
## method: spread_orientations
Adds method to modify_volume_element in `matflow-damask/main.py` to add quaternions around a specified quaternion of a specified phase.

e.g:
- The user specifies the target phase via its phase (label): `Ti-alpha`
- The user also specifies the max_ori_spread: 10 `#degrees`

Method currently samples 100 orientations and spreads them randomly around the base ori within the defined spread.
This can be used to have more of a 'spreaded' initial texture for a model without having to recreate the VE.

This is stable (matflow validate and go work) but upon running the following error occurs:
```
Traceback (most recent call last):
  File "/mnt/iusers01/jf01/y15576gb/.local/bin/matflow", line 10, in <module>
    sys.exit(cli())
  File "/mnt/iusers01/jf01/y15576gb/.local/lib/python3.7/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/mnt/iusers01/jf01/y15576gb/.local/lib/python3.7/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/mnt/iusers01/jf01/y15576gb/.local/lib/python3.7/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/mnt/iusers01/jf01/y15576gb/.local/lib/python3.7/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/mnt/iusers01/jf01/y15576gb/.local/lib/python3.7/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/mnt/iusers01/jf01/y15576gb/.local/lib/python3.7/site-packages/matflow/cli.py", line 63, in process_task
    api.process_task(task_idx, iteration_idx, directory, is_array=array)
  File "/mnt/iusers01/jf01/y15576gb/.local/lib/python3.7/site-packages/matflow/api.py", line 132, in process_task
    workflow.process_task(task_idx, iteration_idx, is_array=is_array)
  File "/mnt/iusers01/jf01/y15576gb/.local/lib/python3.7/site-packages/matflow/models/workflow.py", line 67, in func_wrap
    return func(self, *args, **kwargs)
  File "/mnt/iusers01/jf01/y15576gb/.local/lib/python3.7/site-packages/matflow/models/workflow.py", line 2209, in process_task
    is_array=False,
  File "/mnt/iusers01/jf01/y15576gb/.local/lib/python3.7/site-packages/matflow/models/workflow.py", line 2053, in process_task_element
    with func_outputs_path.open('rb') as handle:
  File "/opt/apps/apps/binapps/anaconda3/2019.07/lib/python3.7/pathlib.py", line 1186, in open
    opener=self._opener)
  File "/opt/apps/apps/binapps/anaconda3/2019.07/lib/python3.7/pathlib.py", line 1039, in _opener
    return self._accessor.open(self, flags, mode)
FileNotFoundError: [Errno 2] No such file or directory: '/net/scratch2/y15576gb/matflow/testruns/test_spread_ori+odf_sections_2022-04-20-154851/task_2_modify_volume_element/task_output_64d7a357641023f76644_element_0.pickle'
``` 
Please do try and run this yourself! An example workflow can be found here:
`/mnt/eps01-rds/Fonseca-Lightform/shared/matflow-debugging/Guy/test_spread_ori+odf_sections_2022-04-20-154851`
**Instructions:**
1. `git clone` (this repository) to your CSF space.
2. `git checkout method/spread_oris` branch.
3. `pip install --user -e matflow-damask/`
4. 'git clone UoM-CSF-matflow/' to the same CSF space.
5. `git checkout dev` branch of `UoM-CSF-matflow/` to get the latest task shemas.
6. In .matflow/config.yml, point to your local cloned `UoM-CSF-matflow` under `task_schema_sources` to use the task schema containing `spread_orientations` method.
7. `matflow validate` to check everything is working
8. `matflow go test_spread_ori+odf_sections_2022-04-20-154851/testing_workflow.yml` to replicate this error.

To switch matflow back to its latest release so everything works, simply copy `/mnt/eps01-rds/jf01-home01/shared/matflow/update_matflow.sh`, paste to command line and enter, then point point `.matflow/config.yml` back to `/mnt/eps01-rds/jf01-home01/shared/matflow/task_schemas.yml` under `task_schema_sources` and `matflow validate` to check.

Any help would be much appreciated and any questions please comment below.
Thanks,
Guy


