### PR TITLE
Dual phase methods

### DIFF
--- a/matflow_damask/main.py
+++ b/matflow_damask/main.py
@@ -462,7 +462,7 @@ def generate_volume_element_random_voronoi_orientations_2(microstructure_seeds, 
     return out
 
 
-def generate_volume_element_from_random_voronoi(
+def generate_volume_element_random_voronoi(
     microstructure_seeds,
     grid_size,
     homog_label,

--- a/matflow_damask/main.py
+++ b/matflow_damask/main.py
@@ -618,7 +618,7 @@ def generate_volume_element_from_random_voronoi_dual_phase_orientations(
     
     oris['quaternions'] = np.vstack([sampled_oris_1, sampled_oris_2])
     
-    outputs = generate_volume_element_from_random_voronoi(
+    outputs = generate_volume_element_random_voronoi(
         microstructure_seeds,
         grid_size,
         homog_label,

--- a/matflow_damask/main.py
+++ b/matflow_damask/main.py
@@ -547,6 +547,91 @@ def generate_volume_element_from_random_voronoi(
     volume_element = validate_volume_element(volume_element)
     return {'volume_element': volume_element}
 
+@func_mapper(
+    task='generate_volume_element',
+    method='random_voronoi_from_dual_phase_orientations'
+)
+def generate_volume_element_from_random_voronoi_dual_phase_orientations(
+    microstructure_seeds,
+    grid_size,
+    homog_label,
+    scale_morphology,
+    scale_update_size,
+    buffer_phase_size,
+    buffer_phase_label,
+    orientations_use_max_precision,
+    orientations_phase_1,
+    orientations_phase_2,
+    RNG_seed=None,
+):
+
+    if len(microstructure_seeds['phase_labels']) != 2:
+        raise ValueError(
+            f"There are not two phase labels to correspond to two orientation sets. "
+            f"`phase_labels` is: {microstructure_seeds['phase_labels']}.")
+
+    ori_1 = validate_orientations(orientations_phase_1)
+    ori_2 = validate_orientations(orientations_phase_2)
+    oris = copy.deepcopy(ori_1)
+    
+    phase_labels_idx = microstructure_seeds['phase_labels_idx']
+    phase_labels = microstructure_seeds['phase_labels']
+    num_grains = len(phase_labels_idx)
+    _, counts = np.unique(phase_labels_idx, return_counts=True)
+    
+    num_ori_1 = ori_1['quaternions'].shape[0]
+    num_ori_2 = ori_2['quaternions'].shape[0]
+    sampled_oris_1 = ori_1['quaternions']
+    sampled_oris_2 = ori_2['quaternions']
+
+    rng = np.random.default_rng(seed=RNG_seed)
+
+    # If there are more orientations than phase label assignments, choose a random subset:
+    if num_ori_1 != counts[0]:
+        try:
+            ori_1_idx = rng.choice(a=num_ori_1, size=counts[0], replace=False)
+        except ValueError as err:
+            raise ValueError(
+                f"Probably an insufficient number of `orientations_phase_1` "
+                f"({num_ori_1} given for phase {phase_labels[0]!r}, whereas {counts[0]} "
+                f"needed). Caught ValueError is: {err}"
+            )
+        sampled_oris_1 = sampled_oris_1[ori_1_idx]
+    if num_ori_2 != counts[1]:
+        try:
+            ori_2_idx = rng.choice(a=num_ori_2, size=counts[1], replace=False)
+        except ValueError as err:
+            raise ValueError(
+                f"Probably an insufficient number of `orientations_phase_2` "
+                f"({num_ori_2} given for phase {phase_labels[1]!r}, whereas {counts[1]} "
+                f"needed). Caught ValueError is: {err}"
+            )
+        sampled_oris_2 = sampled_oris_2[ori_2_idx]
+
+    ori_idx = np.ones(num_grains) * np.nan
+    for idx, i in enumerate(counts):
+        ori_idx[phase_labels_idx == idx] = np.arange(i) + np.sum(counts[:idx])
+
+    if np.any(np.isnan(ori_idx)):
+        raise RuntimeError("Not all phases have an orientation assigned!")
+    ori_idx = ori_idx.astype(int)
+    
+    oris['quaternions'] = np.vstack([sampled_oris_1, sampled_oris_2])
+    
+    outputs = generate_volume_element_from_random_voronoi(
+        microstructure_seeds,
+        grid_size,
+        homog_label,
+        scale_morphology,
+        scale_update_size,
+        buffer_phase_size,
+        buffer_phase_label,
+        orientations_use_max_precision,
+        orientations=oris,
+        orientations_idx=ori_idx,
+    )
+    return outputs
+
 
 @func_mapper(task='generate_volume_element', method='from_damask_input_files')
 def generate_volume_element_from_damask_input_files(geom_path, material_path, orientations):

--- a/matflow_damask/main.py
+++ b/matflow_damask/main.py
@@ -66,6 +66,14 @@ def seeds_from_random(
     if phase_label is not None and phase_labels is not None:
         raise ValueError(f"Specify exactly one of `phase_label` and `phase_labels`.")
 
+    if (
+        (phase_label is not None and not isinstance(phase_label, str)) or 
+        (phase_labels is not None and not isinstance(phase_labels, list))
+    ):
+        raise ValueError(
+            f"Specify `phase_label` as a string, or `phase_labels` as a list of strings."
+        )
+
     if phase_labels is None:
         phase_labels = [phase_label]
         phase_labels_idx = np.zeros(num_grains)


### PR DESCRIPTION
- Support specifying multiple phases in `seeds_from_random`
- Generalise `generate_volume_element_random_voronoi` to support multiple phase labels
- Add `generate_volume_element_from_random_voronoi_dual_phase_orientations`