### PR TITLE
Dev

### DIFF
--- a/matflow_damask/main.py
+++ b/matflow_damask/main.py
@@ -462,7 +462,7 @@ def generate_volume_element_random_voronoi_orientations_2(microstructure_seeds, 
     return out
 
 
-def generate_volume_element_from_random_voronoi(
+def generate_volume_element_random_voronoi(
     microstructure_seeds,
     grid_size,
     homog_label,

--- a/matflow_damask/main.py
+++ b/matflow_damask/main.py
@@ -26,6 +26,7 @@ from damask_parse.utils import (
     add_volume_element_buffer_zones,
     validate_orientations,
     validate_volume_element,
+    spread_orientations,
 )
 from damask_parse import __version__ as damask_parse_version
 from matflow.scripting import get_wrapper_script
@@ -339,6 +340,12 @@ def modify_volume_element_add_buffer_zones(volume_element, buffer_sizes,
         )
     }
     return out
+
+
+@func_mapper(task='modify_volume_element', method='spread_orientations')
+def modify_volume_element_spread_orientations(volume_element, phases, stddev_degrees):
+    VE = spread_orientations(volume_element, phases, sigmas=stddev_degrees)
+    return {"volume_element": VE}
 
 
 @func_mapper(task='modify_volume_element', method='new_orientations')

--- a/matflow_damask/main.py
+++ b/matflow_damask/main.py
@@ -618,7 +618,7 @@ def generate_volume_element_from_random_voronoi_dual_phase_orientations(
     
     oris['quaternions'] = np.vstack([sampled_oris_1, sampled_oris_2])
     
-    outputs = generate_volume_element_from_random_voronoi(
+    outputs = generate_volume_element_random_voronoi(
         microstructure_seeds,
         grid_size,
         homog_label,

--- a/matflow_damask/main.py
+++ b/matflow_damask/main.py
@@ -547,6 +547,91 @@ def generate_volume_element_from_random_voronoi(
     volume_element = validate_volume_element(volume_element)
     return {'volume_element': volume_element}
 
+@func_mapper(
+    task='generate_volume_element',
+    method='random_voronoi_from_dual_phase_orientations'
+)
+def generate_volume_element_from_random_voronoi_dual_phase_orientations(
+    microstructure_seeds,
+    grid_size,
+    homog_label,
+    scale_morphology,
+    scale_update_size,
+    buffer_phase_size,
+    buffer_phase_label,
+    orientations_use_max_precision,
+    orientations_phase_1,
+    orientations_phase_2,
+    RNG_seed=None,
+):
+
+    if len(microstructure_seeds['phase_labels']) != 2:
+        raise ValueError(
+            f"There are not two phase labels to correspond to two orientation sets. "
+            f"`phase_labels` is: {microstructure_seeds['phase_labels']}.")
+
+    ori_1 = validate_orientations(orientations_phase_1)
+    ori_2 = validate_orientations(orientations_phase_2)
+    oris = copy.deepcopy(ori_1)
+    
+    phase_labels_idx = microstructure_seeds['phase_labels_idx']
+    phase_labels = microstructure_seeds['phase_labels']
+    num_grains = len(phase_labels_idx)
+    _, counts = np.unique(phase_labels_idx, return_counts=True)
+    
+    num_ori_1 = ori_1['quaternions'].shape[0]
+    num_ori_2 = ori_2['quaternions'].shape[0]
+    sampled_oris_1 = ori_1['quaternions']
+    sampled_oris_2 = ori_2['quaternions']
+
+    rng = np.random.default_rng(seed=RNG_seed)
+
+    # If there are more orientations than phase label assignments, choose a random subset:
+    if num_ori_1 != counts[0]:
+        try:
+            ori_1_idx = rng.choice(a=num_ori_1, size=counts[0], replace=False)
+        except ValueError as err:
+            raise ValueError(
+                f"Probably an insufficient number of `orientations_phase_1` "
+                f"({num_ori_1} given for phase {phase_labels[0]!r}, whereas {counts[0]} "
+                f"needed). Caught ValueError is: {err}"
+            )
+        sampled_oris_1 = sampled_oris_1[ori_1_idx]
+    if num_ori_2 != counts[1]:
+        try:
+            ori_2_idx = rng.choice(a=num_ori_2, size=counts[1], replace=False)
+        except ValueError as err:
+            raise ValueError(
+                f"Probably an insufficient number of `orientations_phase_2` "
+                f"({num_ori_2} given for phase {phase_labels[1]!r}, whereas {counts[1]} "
+                f"needed). Caught ValueError is: {err}"
+            )
+        sampled_oris_2 = sampled_oris_2[ori_2_idx]
+
+    ori_idx = np.ones(num_grains) * np.nan
+    for idx, i in enumerate(counts):
+        ori_idx[phase_labels_idx == idx] = np.arange(i) + np.sum(counts[:idx])
+
+    if np.any(np.isnan(ori_idx)):
+        raise RuntimeError("Not all phases have an orientation assigned!")
+    ori_idx = ori_idx.astype(int)
+    
+    oris['quaternions'] = np.vstack([sampled_oris_1, sampled_oris_2])
+    
+    outputs = generate_volume_element_from_random_voronoi(
+        microstructure_seeds,
+        grid_size,
+        homog_label,
+        scale_morphology,
+        scale_update_size,
+        buffer_phase_size,
+        buffer_phase_label,
+        orientations_use_max_precision,
+        orientations=oris,
+        orientations_idx=ori_idx,
+    )
+    return outputs
+
 
 @func_mapper(task='generate_volume_element', method='from_damask_input_files')
 def generate_volume_element_from_damask_input_files(geom_path, material_path, orientations):

--- a/matflow_damask/main.py
+++ b/matflow_damask/main.py
@@ -66,6 +66,14 @@ def seeds_from_random(
     if phase_label is not None and phase_labels is not None:
         raise ValueError(f"Specify exactly one of `phase_label` and `phase_labels`.")
 
+    if (
+        (phase_label is not None and not isinstance(phase_label, str)) or 
+        (phase_labels is not None and not isinstance(phase_labels, list))
+    ):
+        raise ValueError(
+            f"Specify `phase_label` as a string, or `phase_labels` as a list of strings."
+        )
+
     if phase_labels is None:
         phase_labels = [phase_label]
         phase_labels_idx = np.zeros(num_grains)

--- a/matflow_damask/utils.py
+++ b/matflow_damask/utils.py
@@ -84,18 +84,28 @@ def apply_single_crystal_parameter_perturbations(single_crystal_params, pert):
     
     params = copy.deepcopy(single_crystal_params)
     if is_scale:
-        for pert_i, add_i in zip(perturbations, addresses):
+        for idx, (pert_i, add_i) in enumerate(zip(perturbations, addresses)):
             if add_i is not None:
                 scale_factor_i = (1 + pert_i)
-                set_by_path(params, add_i, get_by_path(params, add_i) * scale_factor_i)
+                new_val = get_by_path(params, add_i) * scale_factor_i
+                for eq_con in pert.get('equal_constraints', []):
+                    eq_con = sorted(eq_con)
+                    if idx > eq_con[0] and idx in eq_con[1:]:
+                        new_val = get_by_path(params, addresses[eq_con[0]])
+                set_by_path(params, add_i, new_val)
     elif is_std_dev:
-        for std_dev_i, add_i in zip(std_devs, addresses):
+        for idx, (std_dev_i, add_i) in enumerate(zip(std_devs, addresses)):
             if add_i is not None:
                 # draw a perturbation from a zero-mean normal distribution
                 rng = np.random.default_rng()
                 pert_i = rng.normal(loc=0.0, scale=std_dev_i)
                 scale_factor_i = (1 + pert_i)
-                set_by_path(params, add_i, get_by_path(params, add_i) * scale_factor_i)
+                new_val = get_by_path(params, add_i) * scale_factor_i
+                for eq_con in pert.get('equal_constraints', []):
+                    eq_con = sorted(eq_con)
+                    if idx > eq_con[0] and idx in eq_con[1:]:
+                        new_val = get_by_path(params, addresses[eq_con[0]])
+                set_by_path(params, add_i, new_val)
 
 
     return params

--- a/matflow_damask/utils.py
+++ b/matflow_damask/utils.py
@@ -1,3 +1,8 @@
+import copy
+
+import numpy as np
+
+
 def get_by_path(root, path):
     """Get a nested dict or list item according to its "key path"
     
@@ -38,3 +43,59 @@ def set_by_path(root, path, value):
     for key in path[:-1]:
         sub_data = sub_data[key]
     sub_data[path[-1]] = value
+
+
+def apply_single_crystal_parameter_perturbations(single_crystal_params, pert):
+    
+    if 'address' in pert and 'addresses' in pert:
+        raise ValueError(f"Specify either `address` or `addresses`.")
+    if 'perturbation' in pert and 'perturbations' in pert:
+        raise ValueError(f"Specify either `perturbation` or `perturbations`.")
+    if 'std_deviation' in pert and 'std_deviations' in pert:
+        raise ValueError(f"Specify either `std_deviation` or `std_deviations`.")
+
+    is_scale = 'perturbation' in pert or 'perturbations' in pert
+    is_std_dev = 'std_deviation' in pert or 'std_deviations' in pert
+    if (is_scale and is_std_dev) or (not is_scale and not is_std_dev):
+        raise ValueError("Specify perturbation as either `perturbations` or `std_deviations`")
+
+    if is_scale:
+        if ('perturbation' in pert and 'addresses' in pert) or ('perturbations' in pert and 'address' in pert):
+            raise ValueError(f"Specify `perturbation` and `address` or `perturbations` and `addresses`.")
+        if 'perturbations' in pert and len(pert['perturbations']) != len(pert['addresses']):
+            raise ValueError(f"The lengths of `perturbations` and `addresses` must be equal")
+
+    elif is_std_dev:
+        if ('std_deviation' in pert and 'addresses' in pert) or ('std_deviations' in pert and 'address' in pert):
+            raise ValueError(f"Specify `std_deviation` and `address` or `std_deviations` and `addresses`.")
+        if 'std_deviations' in pert and len(pert['std_deviations']) != len(pert['addresses']):
+            raise ValueError(f"The lengths of `perturbations` and `addresses` must be equal")    
+
+    if 'perturbation' in pert:
+        perturbations = [pert['perturbation']]
+        addresses = [pert.get('address')]
+    elif 'std_deviation' in pert:
+        std_devs = [pert['std_deviations']]
+        addresses = [pert.get('address')]
+    else:
+        perturbations = pert.get('perturbations')
+        std_devs = pert.get('std_deviations')
+        addresses = pert.get('addresses')
+    
+    params = copy.deepcopy(single_crystal_params)
+    if is_scale:
+        for pert_i, add_i in zip(perturbations, addresses):
+            if add_i is not None:
+                scale_factor_i = (1 + pert_i)
+                set_by_path(params, add_i, get_by_path(params, add_i) * scale_factor_i)
+    elif is_std_dev:
+        for std_dev_i, add_i in zip(std_devs, addresses):
+            if add_i is not None:
+                # draw a perturbation from a zero-mean normal distribution
+                rng = np.random.default_rng()
+                pert_i = rng.normal(loc=0.0, scale=std_dev_i)
+                scale_factor_i = (1 + pert_i)
+                set_by_path(params, add_i, get_by_path(params, add_i) * scale_factor_i)
+
+
+    return params


### PR DESCRIPTION
- Parameter `single_crystal_parameter_perturbation` in task `simulate_volume_element_loading`:
  -  support specifying a relative standard deviation (`std_deviations`) of a normal distribution to be sampled.
  - support `equal_constraints` for setting multiple perturbed values to be equal (e.g. initial and saturated CRSS values)
- Add `spread_orientations` method to task `modify_volume_element`
- Support specifying multiple phases in `seeds_from_random`
- Generalise `generate_volume_element_random_voronoi` to support multiple phase labels
- Add `generate_volume_element_from_random_voronoi_dual_phase_orientations`